### PR TITLE
remove conditional target declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dotnet: 2.2.101
 branches:
   only:
   - master
-script: "./build.sh"
+script: "./build.sh default publish"
 git:
   depth: false
 before_install:


### PR DESCRIPTION
FWIW, this is another possibility for declaring your targets:

- No conditional declarations:
  - Consistent list of targets, regardless of environment.
  - Consistent dependencies for the `default` target.
- Packing by default:
  - The Appveyor build proves that the packages can be created in Windows.
  - Useful for smoke testing the actual packages locally.